### PR TITLE
feat: add support for openai (compatible) LLM providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 bin/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -56,12 +56,24 @@ After installing Chat With Code, you're just a few steps away from a conversatio
     2. Authenticate securely using the following command:
 
          ```sh
+         # azure
          cwc login \
+           --provider "azure" \
            --api-key=$API_KEY \
            --endpoint "https://your-endpoint.openai.azure.com/" \
            --api-version "2023-12-01-preview" \
            --deployment-model "gpt-4-turbo"
          ```
+
+         ```sh
+         # openai (compatible)
+         cwc login \
+           --provider "openai" \
+           --api-key=$API_KEY \
+           --endpoint "http://localhost:11434" \
+           --api-version "v1" \
+           --model "codellama"
+         ```     
 
    > **Security Notice**: Never input your API key directly into the command-line arguments to prevent potential exposure in shell history and process listings. The API key is securely stored in your personal keyring.
 

--- a/cmd/cwc.go
+++ b/cmd/cwc.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
+
 	"github.com/emilkje/cwc/pkg/pathmatcher"
 	"github.com/sashabaranov/go-openai"
 	"github.com/spf13/cobra"
-	"io"
 
 	"github.com/emilkje/cwc/pkg/config"
 	"github.com/emilkje/cwc/pkg/errors"
@@ -182,10 +183,13 @@ If you have multiple files called 'main.go' for example, you can use the --paths
 
 		for {
 			req := openai.ChatCompletionRequest{
-				Model: openai.GPT4TurboPreview,
+				Model: config.Cfg.Model,
 				//MaxTokens: 4096,
 				Messages: messages,
 				Stream:   true,
+			}
+			if config.Cfg.Provider == "azure" && config.Cfg.Model == "" {
+				req.Model = openai.GPT4TurboPreview
 			}
 
 			ctx := context.Background()
@@ -243,7 +247,6 @@ If you have multiple files called 'main.go' for example, you can use the --paths
 }
 
 func init() {
-
 	CwcCmd.Flags().StringVarP(&includeFlag, "include", "i", ".*", "a regular expression to match files to include")
 	CwcCmd.Flags().StringVarP(&excludeFlag, "exclude", "x", "", "a regular expression to match files to exclude")
 	CwcCmd.Flags().StringSliceVarP(&pathsFlag, "paths", "p", []string{"."}, "a list of paths to search for files")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/emilkje/cwc/pkg/config"
 	"github.com/emilkje/cwc/pkg/errors"
 	"github.com/emilkje/cwc/pkg/ui"
@@ -12,14 +14,16 @@ var (
 	endpointFlag        string
 	apiVersionFlag      string
 	modelDeploymentFlag string
+	modelFlag           string
+	providerFlag        string
 )
 
 // Declaration of a new cobra command for login
 var loginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Authenticate with Azure OpenAI",
-	Long: `Login will prompt you to enter your Azure OpenAI API key and other relevant information required for authentication. 
-Your credentials will be stored securely in your keyring and will never be exposed on the file system directly.
+	Short: "Authenticate with LLM provider",
+	Long: `Login will prompt you to enter your provider name, API key and other relevant information required for authentication.
+Your credentials will be stored securely in your keyring and will never be exposed on the file system directly. 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -28,28 +32,43 @@ Your credentials will be stored securely in your keyring and will never be expos
 		endpoint := endpointFlag
 		apiVersion := apiVersionFlag
 		modelDeployment := modelDeploymentFlag
+		model := modelFlag
+		provider := strings.ToLower(providerFlag)
+
+		if provider == "" {
+			ui.PrintMessage("Enter Provider name: ", ui.MessageTypeInfo)
+			provider = config.SanitizeInput(ui.ReadUserInput())
+		}
 
 		if apiKeyFlag == "" {
-			ui.PrintMessage("Enter the Azure OpenAI API Key: ", ui.MessageTypeInfo)
+			ui.PrintMessage("Enter the API Key: ", ui.MessageTypeInfo)
 			apiKey = config.SanitizeInput(ui.ReadUserInput())
 		}
 
 		if endpointFlag == "" {
-			ui.PrintMessage("Enter the Azure OpenAI API Endpoint: ", ui.MessageTypeInfo)
+			ui.PrintMessage("Enter the API Endpoint: ", ui.MessageTypeInfo)
 			endpoint = config.SanitizeInput(ui.ReadUserInput())
 		}
 
 		if apiVersionFlag == "" {
-			ui.PrintMessage("Enter the Azure OpenAI API Version: ", ui.MessageTypeInfo)
+			ui.PrintMessage("Enter the API Version: ", ui.MessageTypeInfo)
 			apiVersion = config.SanitizeInput(ui.ReadUserInput())
 		}
-
-		if modelDeploymentFlag == "" {
-			ui.PrintMessage("Enter the Azure OpenAI Model Deployment: ", ui.MessageTypeInfo)
-			modelDeployment = config.SanitizeInput(ui.ReadUserInput())
+		if provider == "azure" {
+			if modelDeploymentFlag == "" {
+				ui.PrintMessage("Enter the Azure OpenAI Model Deployment: ", ui.MessageTypeInfo)
+				modelDeployment = config.SanitizeInput(ui.ReadUserInput())
+			}
 		}
 
-		cfg := config.NewConfig(endpoint, apiVersion, modelDeployment)
+		if provider == "openai" {
+			if modelFlag == "" {
+				ui.PrintMessage("Enter the Model name: ", ui.MessageTypeInfo)
+				model = config.SanitizeInput(ui.ReadUserInput())
+			}
+		}
+
+		cfg := config.NewConfig(provider, endpoint, apiVersion, modelDeployment, model)
 		cfg.SetAPIKey(apiKey)
 
 		err := config.SaveConfig(cfg)
@@ -72,8 +91,10 @@ Your credentials will be stored securely in your keyring and will never be expos
 func init() {
 
 	// Add flags to the login command
-	loginCmd.Flags().StringVarP(&apiKeyFlag, "api-key", "k", "", "Azure OpenAI API Key")
-	loginCmd.Flags().StringVarP(&endpointFlag, "endpoint", "e", "", "Azure OpenAI API Endpoint")
-	loginCmd.Flags().StringVarP(&apiVersionFlag, "api-version", "v", "", "Azure OpenAI API Version")
-	loginCmd.Flags().StringVarP(&modelDeploymentFlag, "model-deployment", "m", "", "Azure OpenAI Model Deployment")
+	loginCmd.Flags().StringVarP(&providerFlag, "provider", "p", "", "Provider name. Supported providers: "+strings.Join(config.SupportedProviders, " "))
+	loginCmd.Flags().StringVarP(&modelFlag, "model", "m", "", "OpenAI (compatible) Model")
+	loginCmd.Flags().StringVarP(&apiKeyFlag, "api-key", "k", "", "API Key")
+	loginCmd.Flags().StringVarP(&endpointFlag, "endpoint", "e", "", "API Endpoint")
+	loginCmd.Flags().StringVarP(&apiVersionFlag, "api-version", "v", "", "API Version")
+	loginCmd.Flags().StringVarP(&modelDeploymentFlag, "model-deployment", "d", "", "Azure OpenAI Model Deployment")
 }


### PR DESCRIPTION
This pull request introduces the ability to integrate with various OpenAI-compatible LLM providers, enhancing the project's flexibility and usability. Resolving #12 

The changes include:

1. Expanded configuration options: 
    - Added "provider" (now required)
    - Supported options are now: azure, openai
    - Added "model" (string)

2. Export configuration in config module so that it is reusable in "cmd" module.
    - This is needed to reference model name in OpenAI client configuration.

3. Update login flow to work with different providers:
    - If azure provider, prompt model-deployment name
    - Change interactive prompt descriptions to not be azure openai specific.

4. Change API request handling for Azure vs OpenAI LLM provider:
    To increase flexibility of the configuration, GPT4 Turbo Preview is no longer hardcoded as the model name. 
    To avoid breaking changes, if provider is "azure" and model string is empty, default to GTP4TurboPreview.

5. Update docs:
    - Add alternative login example in README
    - Update azure login example (add provider attribute)

